### PR TITLE
Fix mapping between x11 Keycodes and evdev scancodes

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -25,7 +25,7 @@ thread_local! {
 pub fn scancode_name(sc: u16) -> String {
     let keysym = XKB_KEYMAP.with(|xkb_keymap| {
         // Get keysym from key.
-        xkb::State::new(xkb_keymap).key_get_one_sym(sc as u32)
+        xkb::State::new(xkb_keymap).key_get_one_sym((sc as u32) + 8)
     });
     let mut key_name = xkb::keysym_get_name(keysym);
     if key_name.len() == 1 {

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -25,7 +25,11 @@ thread_local! {
 pub fn scancode_name(sc: u16) -> String {
     let keysym = XKB_KEYMAP.with(|xkb_keymap| {
         // Get keysym from key.
-        xkb::State::new(xkb_keymap).key_get_one_sym((sc as u32) + 8)
+        //
+        // According to the xkbcommon documentation, there is a fixed offset
+        // of 8 between X11-compatible keymaps and Linux evdev scancodes:
+        // https://docs.rs/xkbcommon/latest/xkbcommon/xkb/type.Keycode.html
+        xkb::State::new(xkb_keymap).key_get_one_sym(sc as u32 + 8)
     });
     let mut key_name = xkb::keysym_get_name(keysym);
     if key_name.len() == 1 {


### PR DESCRIPTION
fixes #5

It seems that according to the xkbcommon documentation (specifically: https://docs.rs/xkbcommon/latest/xkbcommon/xkb/type.Keycode.html), there is a fixed offset of 8 between X11-compatible keymaps and Linux evdev scancodes.