### PR TITLE
Check if using XWayland

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -334,7 +334,7 @@ pub fn key_map_to_winit_vkey(key: KeyMap) -> Option<winit::event::VirtualKeyCode
 fn new_keymap() -> Result<xkb::Keymap, KeymapError> {
     match std::env::var("XDG_SESSION_TYPE") {
         Ok(session_type) => match session_type.as_str() {
-            "wayland" => return new_wayland_keymap(),
+            "wayland" if std::env::var("WAYLAND_DISPLAY").is_ok() => return new_wayland_keymap(),
             "x11" => return new_x11_keymap(),
             _ => (),
         },


### PR DESCRIPTION
The current implementation uses the `XDG_SESSION_TYPE` variable to determine if Wayland is being used. This does not account for users opting to force the usage of X through XWayland, which would be done by unsetting the environment variable `WAYLAND_DISPLAY`. This PR accounts for the unsetting of the `WAYLAND_DISPLAY` variable by falling back to the X11 method.